### PR TITLE
Version 2.10.0

### DIFF
--- a/versioning/version.yaml
+++ b/versioning/version.yaml
@@ -1,6 +1,6 @@
 - Ontology:
     id: http://www.purl.org/ogit/OGIT
-    version: 2.9.0
+    version: 2.10.0
     history:
       - id: 1.0.0
         changelog: |


### PR DESCRIPTION
Bump version number to match entry in history.

See #213, please tag this after merge as  `2.10.0`.