### PR TITLE
Added connection between ogit/Forum/Award entities

### DIFF
--- a/SGO/sgo/verbs/precedes.yaml
+++ b/SGO/sgo/verbs/precedes.yaml
@@ -23,6 +23,8 @@
         to: http://www.purl.org/ogit/License
       - from: http://www.purl.org/ogit/Forum/FeedEntry
         to: http://www.purl.org/ogit/Forum/FeedEntry
+      - from: http://www.purl.org/ogit/Forum/Award
+        to: http://www.purl.org/ogit/Forum/Award
     history:
       - id: 1
         date: 2015-05-21
@@ -36,3 +38,7 @@
         date: 2015-12-10
         description: change entity name from ogit/ServiceManagement/ChangeTask to ogit/ServiceManagement/SubTask
         modified-by: Peter Larem
+      - id: 4
+        date: 2015-12-14
+        description: Added allowed between `ogit/Forum/Award`s
+        modified-by: cwalker@arago.de

--- a/versioning/version.yaml
+++ b/versioning/version.yaml
@@ -1,16 +1,16 @@
 - Ontology:
     id: http://www.purl.org/ogit/OGIT
-    version: 2.10.0
+    version: 2.11.0
     history:
       - id: 1.0.0
         changelog: |
-          initial ontology 
+          initial ontology
         date: 2015-05-21
         creator: Peter Larem
     history:
       - id: 2.0.0
         changelog: |
-          Refactoring the whole ontology in the course of the "cleanOGIT" project 
+          Refactoring the whole ontology in the course of the "cleanOGIT" project
         date: 2015-05-27
         creator: Peter Larem
     history:
@@ -34,7 +34,7 @@
     history:
       - id: 2.4.0
         changelog: |
-          Add new attribute ogit/ServiceManagement/resolvedInTime 
+          Add new attribute ogit/ServiceManagement/resolvedInTime
           Added to ogit/ServiceManagement/SLA
           Removed ogit/Software/Connector => ogit/opens ogit/ServiceManagement/Incident
           Removed ogit/Software/Connector => ogit/opens ogit/ServiceManagement/ConfigurationItem
@@ -79,4 +79,9 @@
           Added ogit/Forum/Group & ogit/Forum/Role and moved TabTab based edges for ogit/Organization & ogit/Organization to new entities
         date: 2015-12-04
         creator: Brendan Moore
-        
+    history:
+      - id: 2.11.0
+        changelog: |
+          Added links between ogit/Forum/Award entities
+        date: 2015-12-14
+        creator: cwalker@arago.de


### PR DESCRIPTION
Added connection between ogit/Forum/Award entities and bumped version `2.11.0`

#### Please tag as `2.11.0` after merge. No tag was created for `2.10.0`

NB I haven't cleaned up the `versioning.yaml` file as I have recommended here: https://github.com/arago/OGIT/issues/213#issuecomment-163178555 pending feedback on that issue.
