### PR TITLE
Added Tabtab Permission edges to KIs/Bundles

### DIFF
--- a/SGO/sgo/verbs/corresponds.yaml
+++ b/SGO/sgo/verbs/corresponds.yaml
@@ -71,6 +71,10 @@
         to: http://www.purl.org/ogit/Person
       - from: http://www.purl.org/ogit/Forum/Invite
         to: http://www.purl.org/ogit/Forum/Topic
+      - from: http://www.purl.org/ogit/Forum/Invite
+        to: http://www.purl.org/ogit/Forum/KnowledgeItemHistory
+      - from: http://www.purl.org/ogit/Forum/Invite
+        to: http://www.purl.org/ogit/Forum/KnowledgeBundle
       
     history:
       - id: 1
@@ -101,3 +105,7 @@
         date: 2015-12-10
         description: change entity name from ogit/ServiceManagement/ChangeTask to ogit/ServiceManagement/SubTask
         modified-by: Peter Larem
+      - id: 6
+        date: 2016-04-04
+        description: Added edge Invite -> KnowledgeItemHistory|KnowledgeBundle
+        modified-by: bmoore@arago.de

--- a/SGO/sgo/verbs/requires.yaml
+++ b/SGO/sgo/verbs/requires.yaml
@@ -39,6 +39,10 @@
         to: http://www.purl.org/ogit/ServiceManagement/Service
       - from: http://www.purl.org/ogit/Forum/Topic
         to: http://www.purl.org/ogit/Forum/Permission
+      - from: http://www.purl.org/ogit/Forum/KnowledgeItemHistory
+        to: http://www.purl.org/ogit/Forum/Permission
+      - from: http://www.purl.org/ogit/Forum/KnowledgeBundle
+        to: http://www.purl.org/ogit/Forum/Permission
     history:
       - id: 1
         date: 2015-05-21
@@ -47,4 +51,8 @@
       - id: 2
         date: 2015-09-03
         description: Added edge Topic -> Permission
+        modified-by: bmoore@arago.de
+      - id: 3
+        date: 2016-04-04
+        description: Added edge KnowledgeItemHistory|KnowledgeBundle -> Permission
         modified-by: bmoore@arago.de


### PR DESCRIPTION
Allows organisation and invite-only based permissions for TabTab KnowledgeItems (`ogit/Forum/KnowledgeItemHistory`) and Bundles (`ogit/Forum/KnowledgeBundle`)

Resolves #226