### PR TITLE
add `ogit/ignores` verb

### DIFF
--- a/SGO/sgo/verbs/ignores.ttl
+++ b/SGO/sgo/verbs/ignores.ttl
@@ -1,0 +1,33 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+@prefix ogit.ServiceManagement: <http://www.purl.org/ogit/ServiceManagement/> .
+
+ogit:ignores
+    a owl:ObjectProperty;
+    rdfs:subPropertyOf ogit:Verb;
+    rdfs:label "ignores";
+    dcterms:description "Verb showing that one entity ignores another - (useful as a mark-as-read flag)";
+    # For ranges, see http://dublincore.org/documents/dcmi-period/
+    dcterms:valid "start=2016-10-14;";
+    dcterms:creator "cwalker@arago.de";
+    dcterms:created "2016-10-14";
+    dcterms:modified "2016-10-14";
+    ogit:admin-contact "arago GmbH";
+    ogit:tech-contact "arago GmbH";
+    ogit:history (
+        [
+            dcterms:identifier "1";
+            dcterms:date "2016-10-14";
+            dcterms:description "initial";
+            dcterms:creator "cwalker@arago.de";
+        ]
+    );
+    ogit:allowed (
+        [
+            ogit:from ogit:Person;
+            ogit:to ogit:Comment;
+        ]
+    );
+.


### PR DESCRIPTION
use case is marking something as *read*, hence the allowed connections between `Person` and `Comment`