### PR TITLE
Adding connections identified as missing

### DIFF
--- a/NTO/Forum/verbs/downloads.ttl
+++ b/NTO/Forum/verbs/downloads.ttl
@@ -2,6 +2,7 @@
 @prefix owl:                    <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:                <http://purl.org/dc/terms/> .
+@prefix ogit.Automation:        <http://www.purl.org/ogit/Automation/> .
 @prefix ogit.Forum:             <http://www.purl.org/ogit/Forum/> .
 
 ogit.Forum:downloads
@@ -13,7 +14,7 @@ ogit.Forum:downloads
 	dcterms:valid "start=2016-02-25;";
 	dcterms:creator "bneal@arago.de";
 	dcterms:created "2016-02-25";
-	dcterms:modified "2016-02-25";
+	dcterms:modified "2018-01-26";
 	ogit:admin-contact "arago GmbH";
 	ogit:tech-contact "arago GmbH";
 	ogit:history (
@@ -29,6 +30,12 @@ ogit.Forum:downloads
 			dcterms:description "add Profile downloads KnowledgeItemHistory";
 			dcterms:creator "cwalker@arago.de";
 		]
+		[
+			dcterms:identifier "3";
+			dcterms:date "2018-01-26";
+			dcterms:description "Adding connections identified as missing for HIRO Community";
+			dcterms:creator "cwalker@arago.de";
+		]
 	);
 	ogit:allowed (
 		[
@@ -38,6 +45,10 @@ ogit.Forum:downloads
 		[
 			ogit:from ogit.Forum:Profile;
 			ogit:to ogit.Forum:KnowledgeItemHistory;
+		]
+		[
+			ogit:from ogit.Forum:Profile;
+			ogit:to ogit.Automation:KnowledgeItem;
 		]
 	);
 .

--- a/SGO/sgo/verbs/connects.ttl
+++ b/SGO/sgo/verbs/connects.ttl
@@ -94,6 +94,12 @@ ogit:connects
 			dcterms:description "Added connections for WorkflowStep -> AcquisitionSession";
 			dcterms:creator "bneal@arago.de";
 		]
+		[
+			dcterms:identifier "13";
+			dcterms:date "2018-03-15";
+			dcterms:description "Adding connections identified as missing for HIRO Community";
+			dcterms:creator "cwalker@arago.de";
+		]
 	);
 	ogit:allowed (
 		[
@@ -375,6 +381,38 @@ ogit:connects
 		[
 			ogit:from ogit.Forum:WorkflowStep;
 			ogit:to ogit.Knowledge:AcquisitionSession;
+		]
+		[
+			ogit:from ogit.Automation:KnowledgeItem;
+			ogit:to ogit.Forum:KnowledgeItemHistory;
+		]
+		[
+			ogit:from ogit.Automation:KnowledgeItem;
+			ogit:to ogit.Forum:WorkflowStep;
+		]
+		[
+			ogit:from ogit.Forum:KnowledgeItemHistory;
+			ogit:to ogit.Forum:WorkflowStep;
+		]
+		[
+			ogit:from ogit.Forum:KnowledgeItemHistory;
+			ogit:to ogit.Automation:KnowledgeItem;
+		]
+		[
+			ogit:from ogit.Forum:KnowledgeBundle;
+			ogit:to ogit.Forum:WorkflowStep;
+		]
+		[
+			ogit:from ogit.Forum:KnowledgeBundle;
+			ogit:to ogit.Forum:KnowledgeItemHistory;
+		]
+		[
+			ogit:from ogit:Comment;
+			ogit:to ogit.Forum:KnowledgeItemHistory;
+		]
+		[
+			ogit:from ogit.Forum:Post;
+			ogit:to ogit.Forum:WorkflowStep;
 		]
 	);
 .

--- a/SGO/sgo/verbs/responds.ttl
+++ b/SGO/sgo/verbs/responds.ttl
@@ -14,7 +14,7 @@ conversation/fourm thread.""";
 	dcterms:valid "start=2015-04-27;";
 	dcterms:creator "cwalker@arago.de";
 	dcterms:created "2015-04-27";
-	dcterms:modified "2017-11-15";
+	dcterms:modified "2018-01-26";
 	ogit:admin-contact "arago GmbH";
 	ogit:tech-contact "arago GmbH";
 	ogit:history (
@@ -48,6 +48,12 @@ conversation/fourm thread.""";
 			dcterms:description "Added edge for `ogit/Forum/Reply` -> `ogit/Forum/Reply`";
 			dcterms:creator "bmoore@arago.de";
 		]
+		[
+			dcterms:identifier "6";
+			dcterms:date "2018-01-26";
+			dcterms:description "Adding connections identified as missing for HIRO Community";
+			dcterms:creator "cwalker@arago.de";
+		]
 	);
 	ogit:allowed (
 		[
@@ -77,6 +83,14 @@ conversation/fourm thread.""";
 		[
 			ogit:from ogit.Forum:Reply;
 			ogit:to ogit.Forum:Reply;
+		]
+		[
+			ogit:from ogit.Forum:Reply;
+			ogit:to ogit.Forum:Rating;
+		]
+		[
+			ogit:from ogit.Forum:Reply;
+			ogit:to ogit:Attachment;
 		]
 	);
 .


### PR DESCRIPTION
We wrote a tool to ensure all connections defined in HIRO Community are both valid and working against the global HIRO Graph.

These changes are the results of this tool identifying missing connections.