### PR TITLE
add Environment.ttl and depend verbs and entities

### DIFF
--- a/SGO/sgo/entities/Environment.ttl
+++ b/SGO/sgo/entities/Environment.ttl
@@ -1,0 +1,35 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit:Environment
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Environment";
+	dcterms:description "An environment describes the overall structure a user, computer or program operates in.";
+	dcterms:valid "start=2018-02-08;";
+	dcterms:creator "Viktor Voss";
+	dcterms:created "2018-02-08";
+	dcterms:modified "2018-02-08";
+	ogit:admin-contact "arago GmbH";
+	ogit:tech-contact "arago GmbH";
+	ogit:scope "SGO";
+	ogit:parent "http://www.purl.org/ogit/Node";
+	ogit:mandatory-attributes (
+		
+	);
+	ogit:optional-attributes (
+		ogit:name
+	);
+	ogit:indexed-attributes (
+		
+	);
+	ogit:history (
+		[
+			dcterms:identifier "1";
+			dcterms:date "2018-02-08";
+			dcterms:description "initial";
+			dcterms:creator "Viktor Voss";
+		]
+	);
+.

--- a/SGO/sgo/entities/Product.ttl
+++ b/SGO/sgo/entities/Product.ttl
@@ -1,0 +1,35 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit:Product
+	a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "Product";
+	dcterms:description "A commercially distributed good or service";
+	dcterms:valid "start=2018-02-08;";
+	dcterms:creator "Viktor Voss";
+	dcterms:created "2018-02-08";
+	dcterms:modified "2018-02-08";
+	ogit:admin-contact "arago GmbH";
+	ogit:tech-contact "arago GmbH";
+	ogit:scope "SGO";
+	ogit:parent "http://www.purl.org/ogit/Node";
+	ogit:mandatory-attributes (
+		
+	);
+	ogit:optional-attributes (
+		ogit:name
+	);
+	ogit:indexed-attributes (
+		
+	);
+	ogit:history (
+		[
+			dcterms:identifier "1";
+			dcterms:date "2018-02-08";
+			dcterms:description "initial";
+			dcterms:creator "Viktor Voss";
+		]
+	);
+.

--- a/SGO/sgo/verbs/hosts.ttl
+++ b/SGO/sgo/verbs/hosts.ttl
@@ -13,7 +13,7 @@ ogit:hosts
 	dcterms:valid "start=2015-10-15;";
 	dcterms:creator "Aymen Ayoub";
 	dcterms:created "2015-10-15";
-	dcterms:modified "2015-10-15";
+	dcterms:modified "2018-02-08";
 	ogit:admin-contact "arago GmbH";
 	ogit:tech-contact "arago GmbH";
 	ogit:history (
@@ -28,6 +28,10 @@ ogit:hosts
 		[
 			ogit:from ogit.Automation:MARSNode;
 			ogit:to ogit.Automation:MARSNode;
+		]
+		[
+			ogit:from ogit:Organization;
+			ogit:to ogit:Environment;
 		]
 	);
 .

--- a/SGO/sgo/verbs/produces.ttl
+++ b/SGO/sgo/verbs/produces.ttl
@@ -36,6 +36,12 @@ ogit:produces
 			dcterms:description "Refactored names of Project/Survey related concepts";
 			dcterms:creator "Fabian Meyer";
 		]
+        [
+            dcterms:identifier "4";
+            dcterms:date "2018-02-08";
+            dcterms:description "Add edge from organization to product.";
+            dcterms:creator "Viktor Voss";
+        ]
 	);
 	ogit:allowed (
 		[
@@ -54,5 +60,10 @@ ogit:produces
             ogit:from ogit:Organization;
             ogit:to ogit.Survey:Iteration;
         ]
+                [
+                        ogit:from ogit:Organization;
+                        ogit:to ogit:Product;
+                ]
+
 	);
 .

--- a/SGO/sgo/verbs/uses.ttl
+++ b/SGO/sgo/verbs/uses.ttl
@@ -755,5 +755,9 @@ ogit:uses
 			ogit:from ogit.Automation:KnowledgePool;
 			ogit:to ogit.Automation:KnowledgeItem;
 		]
+                [
+                        ogit:from ogit:Organization;
+                        ogit:to ogit:Product;
+                ]
 	);
 .

--- a/SGO/sgo/verbs/utilizes.ttl
+++ b/SGO/sgo/verbs/utilizes.ttl
@@ -1,0 +1,31 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit:utilizes
+	a owl:ObjectProperty;
+	rdfs:subPropertyOf ogit:Verb;
+	rdfs:label "utilizes";
+	dcterms:description "This verb means a effective usage of something, for example a component.";
+	dcterms:valid "start=2018-02-08;";
+	dcterms:creator "Viktor Voss";
+	dcterms:created "2018-02-08";
+	dcterms:modified "2018-02-08";
+	ogit:admin-contact "arago GmbH";
+	ogit:tech-contact "arago GmbH";
+	ogit:history (
+		[
+			dcterms:identifier "1";
+			dcterms:date "2018-02-08";
+			dcterms:description "initial";
+			dcterms:creator "Viktor Voss";
+		]
+	);
+	ogit:allowed (
+		[
+			ogit:from ogit:Environment;
+			ogit:to ogit:Product;
+		]
+	);
+.


### PR DESCRIPTION
those changes allow us to model the client - partner -vendor scenario needed for HIRO Portal and HIRO Desktop + it is the requirement for a so called "environment switch" feature in HIRO Desktop, that allows you to switch between different environments and installations