### PR TITLE
Add ogit type for terms and conditions

### DIFF
--- a/SGO/sgo/entities/TermsAndConditions.ttl
+++ b/SGO/sgo/entities/TermsAndConditions.ttl
@@ -1,0 +1,37 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit:TermsAndConditions
+  a rdfs:Class;
+	rdfs:subClassOf ogit:Entity;
+	rdfs:label "TermsAndConditions";
+  dcterms:description "Terms and conditions contains terms of use to be accepted by users";
+  dcterms:valid "start=2018-04-18;";
+	dcterms:creator "Aman Kubanychbek";
+	dcterms:created "2018-04-18";
+  dcterms:modified "2018-04-18";
+	ogit:admin-contact "arago GmbH";
+	ogit:tech-contact "arago GmbH";
+	ogit:scope "SGO";
+	ogit:parent "http://www.purl.org/ogit/Node";
+	ogit:any-attributes "true";
+	ogit:mandatory-attributes (
+		ogit:name
+		ogit:body
+	);
+	ogit:optional-attributes (
+		ogit:description
+	);
+  ogit:indexed-attributes (
+		ogit:name
+	);
+	ogit:history (
+		[
+			dcterms:identifier "1";
+			dcterms:date "2018-04-18";
+			dcterms:description "initial";
+			dcterms:creator "Aman Kubanychbek";
+		]
+	);
+.

--- a/SGO/sgo/entities/TermsAndConditions.ttl
+++ b/SGO/sgo/entities/TermsAndConditions.ttl
@@ -3,14 +3,14 @@
 @prefix dcterms:                <http://purl.org/dc/terms/> .
 
 ogit:TermsAndConditions
-  a rdfs:Class;
+	a rdfs:Class;
 	rdfs:subClassOf ogit:Entity;
 	rdfs:label "TermsAndConditions";
-  dcterms:description "Terms and conditions contains terms of use to be accepted by users";
-  dcterms:valid "start=2018-04-18;";
+	dcterms:description "Terms and conditions contains terms of use to be accepted by users";
+	dcterms:valid "start=2018-04-18;";
 	dcterms:creator "Aman Kubanychbek";
 	dcterms:created "2018-04-18";
-  dcterms:modified "2018-04-18";
+	dcterms:modified "2018-04-18";
 	ogit:admin-contact "arago GmbH";
 	ogit:tech-contact "arago GmbH";
 	ogit:scope "SGO";
@@ -23,7 +23,7 @@ ogit:TermsAndConditions
 	ogit:optional-attributes (
 		ogit:description
 	);
-  ogit:indexed-attributes (
+	ogit:indexed-attributes (
 		ogit:name
 	);
 	ogit:history (

--- a/SGO/sgo/verbs/accepts.ttl
+++ b/SGO/sgo/verbs/accepts.ttl
@@ -29,5 +29,9 @@ ogit:accepts
 			ogit:from ogit.Forum:Profile;
 			ogit:to ogit.Forum:Invite;
 		]
+		[
+			ogit:from ogit:Person;
+			ogit:to ogit:TermsAndConditions;
+		]
 	);
 .


### PR DESCRIPTION
New entity and verb usage to track:
- terms of use content by project (arago project code) and type (i.e. role of user);
- acceptance of terms of use by the users.

Free attributes allowed to specify information about project code and type (requirements are not very clear for now).