### PR TITLE
Extend Task entity for reuse in both directions

### DIFF
--- a/SGO/sgo/entities/Task.ttl
+++ b/SGO/sgo/entities/Task.ttl
@@ -21,6 +21,9 @@ ogit:Task
 		ogit:description
 		ogit:status
 		ogit:positionNumber
+		ogit:type
+		ogit:question
+		ogit:response
 	);
 	ogit:indexed-attributes (
 		ogit:name


### PR DESCRIPTION
`ogit/question` - can be used as question(request) from asking side.
`ogit/responce` - can be used as result of request from answering side.

`ogit/type` - should be used to differentiate the type of task, for example
in subscriptions. (If some component handle only one type of task, than it
must specify ogit/type or its absence in subscription query).

`ogit/type` - is used as