### PR TITLE
Fix broken ontology

### DIFF
--- a/NTO/SalesDistribution/entities/SalesOrder.ttl
+++ b/NTO/SalesDistribution/entities/SalesOrder.ttl
@@ -21,6 +21,7 @@ ogit.SalesDistribution:SalesOrder
     ogit.SalesDistribution:amount
     ogit:currency
     ogit:description
+    ogit:name
     ogit:status
   );
   ogit:indexed-attributes (


### PR DESCRIPTION
ogit/name was removed as mandatory attribute, but not added as optional which causes several issues, e.g.:

{"error":{"message":"could not change attribute of type: ogit\/name if used in 688 vertices for entity: ogit\/SalesDistribution\/OpenItem"}}