### PR TITLE
Revert "Changed title attribute to name on the Audit entity types."

### DIFF
--- a/NTO/Audit/entities/Audit.ttl
+++ b/NTO/Audit/entities/Audit.ttl
@@ -16,7 +16,7 @@ ogit.Audit:Audit
 	ogit:mandatory-attributes (
 	);
 	ogit:optional-attributes (
-            ogit:name
+            ogit:title
 	);
     ogit:indexed-attributes (
     );

--- a/NTO/Audit/entities/Batch.ttl
+++ b/NTO/Audit/entities/Batch.ttl
@@ -15,7 +15,7 @@ ogit.Audit:Batch
 	ogit:mandatory-attributes (
 	);
 	ogit:optional-attributes (
-            ogit:name
+            ogit:title
 	);
     ogit:indexed-attributes (
     );

--- a/NTO/Audit/entities/Sample.ttl
+++ b/NTO/Audit/entities/Sample.ttl
@@ -16,7 +16,7 @@ ogit.Audit:Sample
 	ogit:mandatory-attributes (
 	);
 	ogit:optional-attributes (
-            ogit:name
+            ogit:title
 						ogit:creationTime
 	);
     ogit:indexed-attributes (


### PR DESCRIPTION
This reverts commit 2f3e262a43e3f461f8cef4843ce1f2151e50c612.
which breaks the existing nodes. This can not be done.