### PR TITLE
Add Group and SubGroup for Knowledge AcquisitionSessions

### DIFF
--- a/NTO/Knowledge/attributes/group.ttl
+++ b/NTO/Knowledge/attributes/group.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+@prefix ogit.Knowledge:         <http://www.purl.org/ogit/Knowledge/> .
+
+ogit.Knowledge:group
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "group";
+    dcterms:description "String indicating the group the session is attributed to";
+    dcterms:valid "start=2020-04-15;";
+    dcterms:creator "Ben Neal";
+.

--- a/NTO/Knowledge/attributes/subGroup.ttl
+++ b/NTO/Knowledge/attributes/subGroup.ttl
@@ -1,0 +1,14 @@
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+@prefix ogit.Knowledge:         <http://www.purl.org/ogit/Knowledge/> .
+
+ogit.Knowledge:subGroup
+    a owl:DatatypeProperty;
+    rdfs:subPropertyOf ogit:Attribute;
+    rdfs:label "subGroup";
+    dcterms:description "String indicating the subGroup the session is attributed to";
+    dcterms:valid "start=2020-04-15;";
+    dcterms:creator "Ben Neal";
+.

--- a/NTO/Knowledge/entities/AcquisitionSession.ttl
+++ b/NTO/Knowledge/entities/AcquisitionSession.ttl
@@ -34,10 +34,14 @@ ogit.Knowledge:AcquisitionSession
         ogit:title
         ogit:description
         ogit.Knowledge:archived
+        ogit.Knowledge:group
+        ogit.Knowledge:subGroup
     );
     ogit:indexed-attributes (
         ogit:title
         ogit:description
+        ogit.Knowledge:group
+        ogit.Knowledge:subGroup
     );
     ogit:allowed (
             [ ogit:contains  ogit:Comment ]


### PR DESCRIPTION
@viteke @SteffenBauer 
Please may to review ~~/ pull in~~ this request. It is needed for the Knowledge Acquisition Tool (KAT) in HIRO 6.x and 7.x