### PR TITLE
Improve KI searching by removing some indexed attributes

### DIFF
--- a/NTO/Automation/entities/KnowledgeItem.ttl
+++ b/NTO/Automation/entities/KnowledgeItem.ttl
@@ -56,9 +56,6 @@ In that case, the KnowledgeItem executes operations, which serves the exploitati
 	ogit:indexed-attributes (
 		ogit:name
 		ogit:description
-		ogit:_creator
-		ogit:_modified-by
-		ogit:_owner
 	);
 	ogit:allowed (
 			[ ogit:relates  ogit.Automation:MARSNodeTemplate ]


### PR DESCRIPTION
There is a bug reported to improve the Searching of KI's in the Knowledge Management Tool.
We currently have a side effect where strings are matched to the ID of the owner, creator, or modifier which results in KIs being erroneously returned.
The owner, creator, and modifier were originally added, as indexed keys, when they were email address which provided useful searching, but now they are IDs this benefit is lost