### PR TITLE
Add device code name

### DIFF
--- a/NTO/Mobile/attributes/deviceCodeName.ttl
+++ b/NTO/Mobile/attributes/deviceCodeName.ttl
@@ -1,0 +1,14 @@
+@prefix ogit.Mobile: <http://www.purl.org/ogit/Mobile/> .
+@prefix ogit:                 <http://www.purl.org/ogit/> .
+@prefix dcterms:              <http://purl.org/dc/terms/> .
+@prefix owl:                  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                 <http://www.w3.org/2000/01/rdf-schema#> .
+
+ogit.Mobile:deviceCodeName
+    a                   owl:DatatypeProperty ;
+    rdfs:subPropertyOf  ogit:Attribute ;
+    rdfs:label          "deviceCodeName" ;
+    dcterms:description """device code names, for ex walleye for google pixel 2.""" ;
+    dcterms:valid       "start=2020-08-31;" ;
+    dcterms:creator     "Kaushik Gondaliya" ;
+.

--- a/NTO/Mobile/entities/AppInstance.ttl
+++ b/NTO/Mobile/entities/AppInstance.ttl
@@ -28,6 +28,7 @@ ogit.Mobile:AppInstance
                                 ogit:manufacturer
                                 ogit.Mobile:deviceModel
                                 ogit.Mobile:devicePlatform
+				ogit.Mobile:deviceCodeName
                                 ogit.Mobile:appConfigMode
                                 ogit.Mobile:bundleID
                                 ogit.Mobile:osRadio


### PR DESCRIPTION
Adds deviceCodeName as en additional identifier for a mobile device. This is required to precisely identify a mobile device since the combination of manufacturer and model is not unique.