### PR TITLE
fix duplicated dcterms:description predicate

### DIFF
--- a/NTO/MARS/Application/attributes/class.ttl
+++ b/NTO/MARS/Application/attributes/class.ttl
@@ -8,8 +8,8 @@ ogit.MARS.Application:class
 	a owl:DatatypeProperty;
 	rdfs:subPropertyOf ogit:Attribute;
 	rdfs:label "class";
-	dcterms:description "Used to classifiy Application nodes. Replaces 'ResourceClass' from MARS-Schema";
-	dcterms:description "  . Replaces 'ApplicationClass' from MARS-Schema";
+	dcterms:description """Used to classifiy Application nodes. Replaces 'ResourceClass' from MARS-Schema.
+		Replaces 'ApplicationClass' from MARS-Schema""";
 	# For ranges, see http://dublincore.org/documents/dcmi-period/
 	dcterms:valid "start=2018-06-01;";
 	dcterms:creator "fotto@arago.de";


### PR DESCRIPTION
Even though syntactically correct, most software will only honor either the first or last occurrence