### PR TITLE
175536931: Allow Team to approve and reject AcquisitionSession

### DIFF
--- a/NTO/Auth/entities/Team.ttl
+++ b/NTO/Auth/entities/Team.ttl
@@ -1,6 +1,7 @@
 @prefix ogit:					<http://www.purl.org/ogit/> .
 @prefix owl:                    <http://www.w3.org/2002/07/owl#> .
 @prefix ogit.Auth:              <http://www.purl.org/ogit/Auth/> .
+@prefix ogit.Knowledge:         <http://www.purl.org/ogit/Knowledge/> .
 @prefix ogit:                   <http://www.purl.org/ogit/> .
 @prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms:                <http://purl.org/dc/terms/> .
@@ -33,5 +34,7 @@ ogit.Auth:Team
 	ogit:allowed (
  [ ogit.Auth:belongs  ogit.Auth:Team ]
  [ ogit.Auth:belongs  ogit.Auth:Organization ]
+ [ ogit:approves  ogit.Knowledge:AcquisitionSession ]
+ [ ogit:rejects  ogit.Knowledge:AcquisitionSession ]
 	);
 .


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175536931

- edge `ogit/approves` connects `ogit/Auth/Team` to `ogit/Knowledge/AcquisitionSession`
- edge `ogit/rejects` connects `ogit/Auth/Team` to `ogit/Knowledge/AcquisitionSession`