### PR TITLE
Expand AutomationIssue by adding the optional attribute savedTimeSeconds

### DIFF
--- a/NTO/Automation/attributes/savedTimeSeconds.ttl
+++ b/NTO/Automation/attributes/savedTimeSeconds.ttl
@@ -8,7 +8,7 @@ ogit.Automation:savedTimeSeconds
 	a owl:DatatypeProperty;
 	rdfs:subPropertyOf ogit:Attribute;
 	rdfs:label "savedTimeSeconds";
-	dcterms:description "An integer which contains the aggregation of all KI .";
+	dcterms:description "An integer which contains the aggregation of all KnowledgeItem manualProcessingTimeSeconds .";
 	dcterms:valid "start=2026-05-15;";
 	dcterms:creator "Meganitrospeed";
 .

--- a/NTO/Automation/attributes/savedTimeSeconds.ttl
+++ b/NTO/Automation/attributes/savedTimeSeconds.ttl
@@ -1,0 +1,14 @@
+@prefix ogit.Automation:        <http://www.purl.org/ogit/Automation/> .
+@prefix ogit:                   <http://www.purl.org/ogit/> .
+@prefix owl:                    <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:                   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms:                <http://purl.org/dc/terms/> .
+
+ogit.Automation:savedTimeSeconds
+	a owl:DatatypeProperty;
+	rdfs:subPropertyOf ogit:Attribute;
+	rdfs:label "savedTimeSeconds";
+	dcterms:description "An integer which contains the aggregation of all KI .";
+	dcterms:valid "start=2026-05-15;";
+	dcterms:creator "Meganitrospeed";
+.

--- a/NTO/Automation/entities/AutomationIssue.ttl
+++ b/NTO/Automation/entities/AutomationIssue.ttl
@@ -44,6 +44,7 @@ IssueCondition is processed first.""";
     	ogit.Automation:webhook
     	ogit.RL:state
     	ogit.RL:totalReward
+		ogit.Automation:savedTimeSeconds
 	);
 	ogit:indexed-attributes (
 		ogit:subject


### PR DESCRIPTION
Expand AutomationIssue by adding the optional attribute savedTimeSeconds which is an aggregate of manualProcessingTimeSeconds

This data can later be used for metrics
### Important Note:

It is recommended **NOT** to merge pull requests on weekends.
